### PR TITLE
fix: trigger-pipeline skip check

### DIFF
--- a/scripts/trigger-pipeline.sh
+++ b/scripts/trigger-pipeline.sh
@@ -45,6 +45,6 @@ PARAM_USER=$(printf '%s\n' "${!PARAM_USER_ENV_VAR}")
 PARAM_REPO=$(printf '%s\n' "${!PARAM_REPO_ENV_VAR}")
 PARAM_BRANCH=$(printf '%s\n' "${!PARAM_BRANCH_ENV_VAR}")
 
-if [[ "$SKIP_TRIGGER" == "false" ]]; then
+if [[ "$SKIP_TRIGGER" == "0" ]]; then
   /tmp/swissknife/trigger_pipeline.sh "$VCS_TYPE" "$PARAM_USER" "$PARAM_REPO" "$PARAM_BRANCH" "$CUSTOM_PARAMS"
 fi

--- a/scripts/trigger-pipeline.sh
+++ b/scripts/trigger-pipeline.sh
@@ -45,6 +45,6 @@ PARAM_USER=$(printf '%s\n' "${!PARAM_USER_ENV_VAR}")
 PARAM_REPO=$(printf '%s\n' "${!PARAM_REPO_ENV_VAR}")
 PARAM_BRANCH=$(printf '%s\n' "${!PARAM_BRANCH_ENV_VAR}")
 
-if [[ "$SKIP_TRIGGER" == "0" ]]; then
+if [[ "$SKIP_TRIGGER" == "0" || "$SKIP_TRIGGER" == "false" ]]; then
   /tmp/swissknife/trigger_pipeline.sh "$VCS_TYPE" "$PARAM_USER" "$PARAM_REPO" "$PARAM_BRANCH" "$CUSTOM_PARAMS"
 fi


### PR DESCRIPTION
Circle is passing the boolean parameter as `"0"` or `"1"` rather `"false"` or `"true"`. 

This meant that the trigger-pipeline was actually calling the `trigger_pipeline.sh` when `install-skip-trigger` was `false`