### PR TITLE
trigger-pipeline tag support #89

### DIFF
--- a/scripts/trigger-pipeline.sh
+++ b/scripts/trigger-pipeline.sh
@@ -11,6 +11,7 @@ fi
 
 mkdir -p /tmp/swissknife/
 
+if [[ "$PARAM_BRANCH_ENV_VAR" != "" ]]; then
 cat > /tmp/swissknife/trigger_pipeline.sh <<'EOF'
   #!/bin/bash -x
   echo "----------------------------------------"
@@ -38,13 +39,47 @@ cat > /tmp/swissknife/trigger_pipeline.sh <<'EOF'
   echo "Finished triggering pipeline"
   echo "----------------------------------------"
 EOF
+else
+cat > /tmp/swissknife/trigger_pipeline.sh <<'EOF'
+  #!/bin/bash -x
+  echo "----------------------------------------"
+  echo "Triggering Pipeline"
+
+  export vcs_type="$1";
+  export username="$2";
+  export reponame="$3";
+  export tag="$4";
+  export params="$5";
+
+  trigger_workflow() {
+    curl --silent -X POST \
+      "https://circleci.com/api/v2/project/$vcs_type/$username/$reponame/pipeline?circle-token=${CIRCLE_TOKEN}" \
+      -H 'Accept: */*' \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "tag": "'$tag'",
+        "parameters": '"$params"'
+      }'
+  }
+
+  trigger_workflow
+
+  echo "Finished triggering pipeline"
+  echo "----------------------------------------"
+EOF
+fi
 
 chmod +x /tmp/swissknife/trigger_pipeline.sh
 
 PARAM_USER=$(printf '%s\n' "${!PARAM_USER_ENV_VAR}")
 PARAM_REPO=$(printf '%s\n' "${!PARAM_REPO_ENV_VAR}")
 PARAM_BRANCH=$(printf '%s\n' "${!PARAM_BRANCH_ENV_VAR}")
+PARAM_TAG=$(printf '%s\n' "${!PARAM_TAG_ENV_VAR}")
 
 if [[ "$SKIP_TRIGGER" == "0" || "$SKIP_TRIGGER" == "false" ]]; then
-  /tmp/swissknife/trigger_pipeline.sh "$VCS_TYPE" "$PARAM_USER" "$PARAM_REPO" "$PARAM_BRANCH" "$CUSTOM_PARAMS"
+  if [[ "$PARAM_BRANCH_ENV_VAR" != "" ]]; then
+    /tmp/swissknife/trigger_pipeline.sh "$VCS_TYPE" "$PARAM_USER" "$PARAM_REPO" "$PARAM_BRANCH" "$CUSTOM_PARAMS"
+  else
+    /tmp/swissknife/trigger_pipeline.sh "$VCS_TYPE" "$PARAM_USER" "$PARAM_REPO" "$PARAM_TAG" "$CUSTOM_PARAMS"
+  fi
 fi

--- a/scripts/trigger-pipeline.sh
+++ b/scripts/trigger-pipeline.sh
@@ -36,7 +36,7 @@ cat > /tmp/swissknife/trigger_pipeline.sh <<'EOF'
   fi
 
   trigger_workflow() {
-    curl -v -X POST \
+    curl --silent -X POST \
       "https://circleci.com/api/v2/project/$vcs_type/$username/$reponame/pipeline?circle-token=${CIRCLE_TOKEN}" \
       -H 'Accept: */*' \
       -H 'Content-Type: application/json' \

--- a/src/commands/trigger-pipeline.yml
+++ b/src/commands/trigger-pipeline.yml
@@ -1,8 +1,8 @@
 description: |
-  Triggers a pipeline on given branch. Also allows to installthe trigger script and not trigger into
+  Triggers a pipeline on given branch. Also allows to install the trigger script and not trigger into
   /tmp/swissknife/trigger_pipeline.sh
   it can be called with the arguments as follows
-  /tmp/swissknife/trigger_pipeline.sh vcstype username reponame branch '{"custom_params": "here"}'
+  /tmp/swissknife/trigger_pipeline.sh vcstype username reponame branch|tag '{"custom_params": "here"}'
 parameters:
   repo-name:
     type: env_var_name
@@ -20,6 +20,10 @@ parameters:
     description: The branch to trigger the pipeline on
     type: env_var_name
     default: CIRCLE_BRANCH
+  tag:
+    description: The tag to trigger the pipeline on
+    type: env_var_name
+    default: CIRCLE_TAG
   custom-parameters:
     description: Custom parameters passed to the pipeline
     type: string
@@ -37,5 +41,6 @@ steps:
         PARAM_USER_ENV_VAR: << parameters.user >>
         PARAM_REPO_ENV_VAR: << parameters.repo-name >>
         PARAM_BRANCH_ENV_VAR: << parameters.branch >>
+        PARAM_TAG_ENV_VAR: << parameters.tag >>
         CUSTOM_PARAMS: << parameters.custom-parameters >>
       command: << include(../scripts/trigger-pipeline.sh) >>

--- a/src/commands/trigger-pipeline.yml
+++ b/src/commands/trigger-pipeline.yml
@@ -2,7 +2,9 @@ description: |
   Triggers a pipeline on given branch. Also allows to install the trigger script and not trigger into
   /tmp/swissknife/trigger_pipeline.sh
   it can be called with the arguments as follows
-  /tmp/swissknife/trigger_pipeline.sh vcstype username reponame branch|tag '{"custom_params": "here"}'
+  /tmp/swissknife/trigger_pipeline.sh vcstype username reponame branch '{"custom_params": "here"}'
+  OR
+  /tmp/swissknife/trigger_pipeline.sh vcstype username reponame -t tag '{"custom_params": "here"}'
 parameters:
   repo-name:
     type: env_var_name


### PR DESCRIPTION
This PR adds support to the `trigger-pipeline` command to support `tag`.

https://circleci.com/docs/api/v2/?section=reference#operation/triggerPipeline

`branch` and `tag` are mutually exclusive and CircleCI automatically handles this in the `CIRCLE_BRANCH` and `CIRCLE_TAG` environment variables. I.e., if `CIRCLE_TAG` is set to a value, then `CIRCLE_BRANCH` will be blank and vice versa.