### PR TITLE
Fix build_and_check_circle_config for custom-config

### DIFF
--- a/src/commands/build_and_check_circle_config.yml
+++ b/src/commands/build_and_check_circle_config.yml
@@ -66,13 +66,13 @@ steps:
           circleci >/dev/null 2>&1 || { echo >&2 "No Circle CI CLI. Either pre-install or update swissknife params"; exit 1; }
         fi
 
-        circleci config pack << parameters.directory-of-src >> > .circleci/config.yml
+        circleci config pack << parameters.directory-of-src >> > << parameters.custom-config >>
         circleci config validate << parameters.custom-config >>
   - when:
       condition: << parameters.fail-if-dirty >>
       steps:
         - fail_if_dirty:
-            pattern: .*circleci/config.yml
+            pattern: << parameters.custom-config >>
             invert-pattern: false
             custom-error-message: << parameters.custom-error-message >>
             print-modified-files: true


### PR DESCRIPTION
## Motification
`build_and_check_circle_config` currently doesn't not work if a `custom-config` is given:
❌ outputs to wrong file
✅ validates correct file
❌ checks wrong pattern for failure

## Description
- `circleci config pack` now uses `<< parameters.custom-config >>`
- `fail_if_dirty` now uses `<< parameters.custom-config >>`