### PR TITLE
Remove sudo from build_and_check_circle_config

### DIFF
--- a/src/commands/build_and_check_circle_config.yml
+++ b/src/commands/build_and_check_circle_config.yml
@@ -23,7 +23,7 @@ parameters:
     type: boolean
     default: true
     description: |
-      Will install the circle cli for you. If false you will need to install it. Needs sudo access.
+      Will install the circle cli for you. If false you will need to install it.
   circle-cli-version:
     type: string
     default: latest
@@ -61,7 +61,7 @@ steps:
           if [[ "<< parameters.circle-cli-version >>" != "latest" ]]; then
             export VERSION="<< parameters.circle-cli-version >>";
           fi
-          curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
+          curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
         else
           circleci >/dev/null 2>&1 || { echo >&2 "No Circle CI CLI. Either pre-install or update swissknife params"; exit 1; }
         fi


### PR DESCRIPTION
Interested to get your thoughts. I have a docker image that doesn't have sudo installed. So I can't rely on sudo. I wonder why this was setup in the first place, but it was presumably because the file permissions of your image were more sensibly locked down.

For now I will install sudo on the CI image to get this to pass. Just curious to hear your thoughts.